### PR TITLE
Add USB Mass Storage (MSC) access to SD card

### DIFF
--- a/firmware/boards/waveshare_esp32s3_lcd316.json
+++ b/firmware/boards/waveshare_esp32s3_lcd316.json
@@ -9,7 +9,7 @@
     "extra_flags": [
       "-DARDUINO_ESP32S3_DEV",
       "-DBOARD_HAS_PSRAM",
-      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_USB_CDC_ON_BOOT=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,6 +10,8 @@ lib_deps =
 build_flags =
     -DLV_CONF_INCLUDE_SIMPLE
     -I src
+    -DCONFIG_TINYUSB_MSC_ENABLED=1
+    -DCONFIG_TINYUSB_CDC_ENABLED=1
 
 monitor_speed = 115200
 upload_speed = 921600

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -74,6 +74,14 @@
 #define FONT_NOTIF    &lv_font_montserrat_28
 #define FONT_BUTTON   &lv_font_montserrat_32
 
+// ----- SD Card (SDMMC 1-bit mode) -----
+// Note: GPIO1 and GPIO2 are shared with the ST7701 3-wire SPI init interface.
+// The SPI init is one-shot at boot; after display.begin() completes, the SDMMC
+// host can safely claim these pins via the GPIO matrix.
+#define PIN_SD_CLK 1
+#define PIN_SD_CMD 2
+#define PIN_SD_D0  42
+
 // ----- Communication Protocol -----
 #define MSG_DISPLAY_TEXT 0x01
 #define MSG_BUTTON 0x02

--- a/firmware/src/sdcard/sdcard_manager.cpp
+++ b/firmware/src/sdcard/sdcard_manager.cpp
@@ -1,0 +1,84 @@
+#include "sdcard_manager.h"
+#include "config.h"
+
+#include <Arduino.h>
+#include <USB.h>
+#include <USBMSC.h>
+#include <SD_MMC.h>
+
+static USBMSC msc;
+
+// --- USB MSC callbacks ---
+
+static int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+    uint32_t secSize = SD_MMC.sectorSize();
+    if (!secSize) return -1;
+    for (uint32_t x = 0; x < bufsize / secSize; x++) {
+        if (!SD_MMC.readRAW((uint8_t*)buffer + (x * secSize), lba + x)) return -1;
+    }
+    return (int32_t)bufsize;
+}
+
+static int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
+    uint32_t secSize = SD_MMC.sectorSize();
+    if (!secSize) return -1;
+    for (uint32_t x = 0; x < bufsize / secSize; x++) {
+        uint8_t blk[secSize];
+        memcpy(blk, buffer + secSize * x, secSize);
+        if (!SD_MMC.writeRAW(blk, lba + x)) return -1;
+    }
+    return (int32_t)bufsize;
+}
+
+static bool onStartStop(uint8_t power_condition, bool start, bool load_eject) {
+    return true;
+}
+
+// --- SDCardManager ---
+
+bool SDCardManager::begin() {
+    // Configure SDMMC pins (1-bit mode).
+    // GPIO1/GPIO2 are shared with the ST7701 SPI init, which is complete by now.
+    SD_MMC.setPins(PIN_SD_CLK, PIN_SD_CMD, PIN_SD_D0);
+
+    // Mount in 1-bit mode (oneWire=true).
+    if (!SD_MMC.begin("/sdcard", /*oneWire=*/true)) {
+        Serial.println("[sdcard] Mount failed — no card or wiring issue");
+        _mounted = false;
+        return false;
+    }
+
+    _mounted = true;
+    Serial.printf("[sdcard] Mounted: %.2f GB (%llu sectors x %u bytes)\n",
+        (double)SD_MMC.totalBytes() / 1024 / 1024 / 1024,
+        (unsigned long long)SD_MMC.numSectors(),
+        SD_MMC.sectorSize());
+    return true;
+}
+
+void SDCardManager::beginUSB() {
+    msc.vendorID("ESP32");
+    msc.productID("CamelPad SD");
+    msc.productRevision("1.0");
+    msc.onRead(onRead);
+    msc.onWrite(onWrite);
+    msc.onStartStop(onStartStop);
+    msc.mediaPresent(_mounted);
+
+    if (_mounted) {
+        msc.begin(SD_MMC.numSectors(), SD_MMC.sectorSize());
+    } else {
+        msc.begin(0, 512);
+    }
+
+    USB.begin();
+    Serial.println("[sdcard] USB MSC started");
+}
+
+uint64_t SDCardManager::totalBytes() const {
+    return _mounted ? SD_MMC.totalBytes() : 0;
+}
+
+uint64_t SDCardManager::usedBytes() const {
+    return _mounted ? SD_MMC.usedBytes() : 0;
+}

--- a/firmware/src/sdcard/sdcard_manager.h
+++ b/firmware/src/sdcard/sdcard_manager.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// SDCardManager initializes the SD card over SDMMC and exposes it as a USB
+// Mass Storage Class (MSC) device via TinyUSB.
+//
+// Call begin() after display.begin() — the SD card shares GPIO1/GPIO2 with
+// the ST7701 3-wire SPI init interface, which is one-shot and done by the
+// time begin() is called.
+//
+// Call beginUSB() after the SD card is mounted to register the USBMSC
+// callbacks and start the USB stack.
+class SDCardManager {
+public:
+    // Mount the SD card. Returns true if a card was found and mounted.
+    bool begin();
+
+    // Register USBMSC read/write callbacks and start USB.
+    // Call this after begin(). Safe to call even if begin() returned false
+    // (host will see "no media present").
+    void beginUSB();
+
+    bool isMounted() const { return _mounted; }
+    uint64_t totalBytes() const;
+    uint64_t usedBytes() const;
+
+private:
+    bool _mounted = false;
+};


### PR DESCRIPTION
## Summary

- Switches firmware USB mode from HWCDC (`ARDUINO_USB_MODE=1`) to TinyUSB OTG (`ARDUINO_USB_MODE=0`), enabling a **composite CDC + MSC** USB device
- The SD card (SDMMC 1-bit, GPIO1/2/42) is now exposed as a removable USB disk when the device is plugged in
- The bridge's CDC serial interface continues to work on the same USB connection — no host-side changes needed

## Changes

- **`boards/waveshare_esp32s3_lcd316.json`**: `ARDUINO_USB_MODE=1` → `0`
- **`platformio.ini`**: add `CONFIG_TINYUSB_MSC_ENABLED=1` and `CONFIG_TINYUSB_CDC_ENABLED=1` build flags
- **`config.h`**: add `PIN_SD_CLK` (GPIO1), `PIN_SD_CMD` (GPIO2), `PIN_SD_D0` (GPIO42) — confirmed from Waveshare manufacturer examples
- **`sdcard/sdcard_manager.h/.cpp`** (new): mounts SD via `SD_MMC` in 1-bit mode, registers `USBMSC` read/write callbacks, and starts `USB.begin()`
- **`main.cpp`**: initializes SD card after `display.begin()` (GPIO1/2 are shared with the ST7701 3-wire SPI init, which is one-shot), then calls `beginUSB()` to bring up the composite stack

## Notes

- GPIO1 and GPIO2 are shared between the ST7701 display SPI init and SDMMC CLK/CMD. The SPI init is one-shot during `display.begin()`, after which the GPIO matrix is free for SDMMC — this matches how the Waveshare factory firmware handles it.
- If no SD card is inserted, the MSC device still enumerates but reports no media present.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)