### PR TITLE
Exclude SD library from PlatformIO build dependencies

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -7,6 +7,8 @@ lib_deps =
     lvgl/lvgl@^9.3.0
     adafruit/Adafruit seesaw Library@^1.7.0
 
+lib_ignore = SD
+
 build_flags =
     -DLV_CONF_INCLUDE_SIMPLE
     -I src


### PR DESCRIPTION
## Summary
This change excludes the SD library from PlatformIO's dependency resolution to prevent conflicts or unnecessary inclusion in the firmware build.

## Key Changes
- Added `lib_ignore = SD` configuration to `platformio.ini` to explicitly exclude the SD library from the build process

## Details
The SD library is now ignored during the PlatformIO build, which may be necessary to:
- Avoid conflicts with other SD card handling implementations
- Reduce firmware size by excluding unused dependencies
- Prevent incompatibilities with the current project configuration

https://claude.ai/code/session_01UKeqBxu7yugsezF8fy8jS1