### PR TITLE
fix: correct seesaw button remapping and add plugin hook logger

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,13 @@
 [tools]
 bun = "latest"
 uv = "latest"
+
+[tasks.run]
+run = "bun run start"
+
+[tasks.build]
+shell = "bash"
+run = "scripts/build-app.sh"
+
+[tasks.test-notification]
+run = "bun run scripts/test-notifications.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "build:x64": "bun build --compile --target bun-darwin-x64 --minify --outfile dist/camel-pad-tray-x64 src/tray.ts",
     "bundle:app": "bash scripts/build-app.sh"
   },
-  "keywords": ["macropad", "serial", "notifications"],
+  "keywords": [
+    "macropad",
+    "serial",
+    "notifications"
+  ],
   "license": "MIT",
   "dependencies": {
     "chokidar": "^3.6.0",

--- a/plugin/hooks/scripts/logger.js
+++ b/plugin/hooks/scripts/logger.js
@@ -1,0 +1,24 @@
+/**
+ * Centralized logger for camel-pad plugin scripts.
+ * All output goes to stderr so it doesn't interfere with JSON on stdout.
+ * Every line is prefixed with [camel-pad] for easy grepping in Claude debug logs.
+ */
+
+const PREFIX = '[camel-pad]';
+
+const logger = {
+  log(...args) {
+    console.error(PREFIX, ...args);
+  },
+  error(...args) {
+    console.error(PREFIX, '[error]', ...args);
+  },
+  send(msg) {
+    console.error(PREFIX, '[send]', typeof msg === 'string' ? msg : JSON.stringify(msg));
+  },
+  recv(msg) {
+    console.error(PREFIX, '[recv]', typeof msg === 'string' ? msg : JSON.stringify(msg));
+  },
+};
+
+module.exports = logger;

--- a/plugin/hooks/scripts/notify.js
+++ b/plugin/hooks/scripts/notify.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const { randomUUID } = require('crypto');
 const yaml = require('yaml');
+const logger = require('./logger');
 
 // Read stdin
 let input = '';
@@ -21,7 +22,7 @@ process.stdin.on('end', async () => {
   try {
     await main(JSON.parse(input));
   } catch (err) {
-    console.error(JSON.stringify({ error: err.message }));
+    logger.error(err.message);
     process.exit(2);
   }
 });
@@ -48,7 +49,7 @@ function parseConfig(configPath) {
 
     return { endpoint, timeout };
   } catch (err) {
-    console.error('Error parsing config:', err.message);
+    logger.error('Error parsing config:', err.message);
     return null;
   }
 }
@@ -65,12 +66,12 @@ async function main(hookInput) {
   }
 
   if (!config.endpoint) {
-    console.error(JSON.stringify({ error: 'No endpoint configured' }));
+    logger.error('No endpoint configured');
     process.exit(2);
   }
 
   if (!config.timeout) {
-    console.error(JSON.stringify({ error: 'No timeout configured' }));
+    logger.error('No timeout configured');
     process.exit(2);
   }
 
@@ -96,15 +97,18 @@ async function main(hookInput) {
     }, timeoutMs);
 
     ws.on('open', () => {
-      ws.send(JSON.stringify({
+      const msg = {
         type: 'notification',
         id: messageId,
         text: notificationText,
         category: notificationCategory
-      }));
+      };
+      logger.send(msg);
+      ws.send(JSON.stringify(msg));
     });
 
     ws.on('message', (data) => {
+      logger.recv(data.toString());
       try {
         const response = JSON.parse(data.toString());
         if (response.type === 'response' && response.id === messageId) {
@@ -116,7 +120,7 @@ async function main(hookInput) {
           }
         }
       } catch (e) {
-        // Ignore parse errors, wait for valid response
+        logger.error('recv parse error:', e.message);
       }
     });
 

--- a/plugin/hooks/scripts/send-message.js
+++ b/plugin/hooks/scripts/send-message.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const { randomUUID } = require('crypto');
 const yaml = require('yaml');
+const logger = require('./logger');
 
 const { getConfigPath } = require('./config-path');
 
@@ -44,7 +45,7 @@ function parseConfig(configPath) {
 
     return { endpoint, timeout };
   } catch (err) {
-    console.error('Error parsing config:', err.message);
+    logger.error('Error parsing config:', err.message);
     return null;
   }
 }
@@ -89,15 +90,13 @@ async function main() {
       }, timeout);
 
       ws.on('open', () => {
-        ws.send(JSON.stringify({
-          type: 'message',
-          id: messageId,
-          text: message,
-          category: 'custom'
-        }));
+        const msg = { type: 'message', id: messageId, text: message, category: 'custom' };
+        logger.send(msg);
+        ws.send(JSON.stringify(msg));
       });
 
       ws.on('message', (data) => {
+        logger.recv(data.toString());
         try {
           const response = JSON.parse(data.toString());
           if (response.id === messageId) {
@@ -106,7 +105,7 @@ async function main() {
             resolve(response);
           }
         } catch (e) {
-          // Ignore parse errors
+          logger.error('recv parse error:', e.message);
         }
       });
 

--- a/plugin/hooks/scripts/test-connection.js
+++ b/plugin/hooks/scripts/test-connection.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 const yaml = require('yaml');
 const { getConfigPath } = require('./config-path');
+const logger = require('./logger');
 
 const configPath = getConfigPath();
 
@@ -53,15 +54,18 @@ async function main() {
       }, timeout);
 
       ws.on('open', () => {
-        ws.send(JSON.stringify({
+        const msg = {
           type: 'test',
           id: messageId,
           text: 'This is a test message from Claude. Press any Key',
           category: 'test'
-        }));
+        };
+        logger.send(msg);
+        ws.send(JSON.stringify(msg));
       });
 
       ws.on('message', (data) => {
+        logger.recv(data.toString());
         try {
           const response = JSON.parse(data.toString());
           if (response.id === messageId) {
@@ -70,7 +74,7 @@ async function main() {
             resolve(response);
           }
         } catch (e) {
-          // Ignore parse errors
+          logger.error('recv parse error:', e.message);
         }
       });
 

--- a/scripts/test-notifications.js
+++ b/scripts/test-notifications.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+/**
+ * Manual test suite for camel-pad notifications
+ *
+ * Sends real notifications to the device via WebSocket, exactly as Claude Code would.
+ * Usage:
+ *   node scripts/test-notifications.js          # interactive menu
+ *   node scripts/test-notifications.js all      # run all tests sequentially
+ *   node scripts/test-notifications.js <n>      # run test number n
+ */
+
+import { WebSocket } from 'ws';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import readline from 'readline';
+import { randomUUID } from 'crypto';
+import yaml from 'yaml';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+function getConfigPath() {
+  let base;
+  if (process.platform === 'darwin') {
+    base = path.join(os.homedir(), 'Library', 'Application Support', 'camel-pad');
+  } else if (process.platform === 'win32') {
+    base = path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'camel-pad');
+  } else {
+    base = path.join(os.homedir(), '.config', 'camel-pad');
+  }
+  return path.join(base, 'config.yaml');
+}
+
+function loadConfig() {
+  const configPath = getConfigPath();
+  if (!fs.existsSync(configPath)) {
+    console.error(`No config found at ${configPath}. Run camel-pad first to create it.`);
+    process.exit(1);
+  }
+  const content = fs.readFileSync(configPath, 'utf8');
+  const config = yaml.parse(content);
+  const endpoint = `ws://${config.server?.host || 'localhost'}:${config.server?.port || 52914}`;
+  const timeoutMs = config.defaults?.timeoutMs || 30000;
+  return { endpoint, timeoutMs };
+}
+
+// ── WebSocket send/receive ────────────────────────────────────────────────────
+
+function sendNotification(endpoint, notification, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(endpoint);
+    let done = false;
+
+    const timer = setTimeout(() => {
+      if (!done) {
+        done = true;
+        ws.close();
+        reject(new Error(`Timeout after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify(notification));
+    });
+
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.id === notification.id) {
+          if (!done) {
+            done = true;
+            clearTimeout(timer);
+            ws.close();
+            resolve(msg);
+          }
+        }
+      } catch (_) {}
+    });
+
+    ws.on('error', (err) => {
+      if (!done) {
+        done = true;
+        clearTimeout(timer);
+        reject(new Error(`WebSocket error: ${err.message}`));
+      }
+    });
+
+    ws.on('close', () => {
+      if (!done) {
+        done = true;
+        clearTimeout(timer);
+        reject(new Error('Connection closed before response'));
+      }
+    });
+  });
+}
+
+// ── Test scenarios ────────────────────────────────────────────────────────────
+
+const TESTS = [
+  {
+    name: 'AskUserQuestion — Yes/No (approve a file edit)',
+    notification: {
+      type: 'notification',
+      text: 'Claude wants to edit src/main.cpp. Allow this change?',
+      category: 'ask_user_question',
+    },
+  },
+  {
+    name: 'AskUserQuestion — Yes/No (run a shell command)',
+    notification: {
+      type: 'notification',
+      text: 'Run: rm -rf dist/ && bun run build',
+      category: 'ask_user_question',
+    },
+  },
+  {
+    name: 'AskUserQuestion — clarification needed',
+    notification: {
+      type: 'notification',
+      text: 'Should I update the firmware or just the bridge?',
+      category: 'ask_user_question',
+    },
+  },
+  {
+    name: 'Generic notification — task complete',
+    notification: {
+      type: 'notification',
+      text: 'Build succeeded. 0 errors, 2 warnings.',
+      category: 'generic',
+    },
+  },
+  {
+    name: 'Generic notification — error',
+    notification: {
+      type: 'notification',
+      text: 'Tests failed: 3 of 12 assertions failed in gesture_test.ts',
+      category: 'generic',
+    },
+  },
+  {
+    name: 'Long text — truncation test',
+    notification: {
+      type: 'notification',
+      text: 'This is a very long notification message that tests how the display handles overflow. It contains many words and should wrap or truncate gracefully on the 820x320 display.',
+      category: 'generic',
+    },
+  },
+  {
+    name: 'Permission request — bash tool',
+    notification: {
+      type: 'notification',
+      text: 'Claude wants to run a bash command: platformio run --target upload',
+      category: 'ask_user_question',
+    },
+  },
+  {
+    name: 'Permission request — write file',
+    notification: {
+      type: 'notification',
+      text: 'Claude wants to write to firmware/src/display/display_manager.cpp',
+      category: 'ask_user_question',
+    },
+  },
+  {
+    name: 'Queue test — 3 rapid notifications',
+    multi: true,
+    notifications: [
+      { type: 'notification', text: 'Notification 1 of 3: Allow git push to main?', category: 'ask_user_question' },
+      { type: 'notification', text: 'Notification 2 of 3: Delete 4 temp files?', category: 'ask_user_question' },
+      { type: 'notification', text: 'Notification 3 of 3: Open browser for settings?', category: 'ask_user_question' },
+    ],
+  },
+  {
+    name: 'Special characters — unicode and symbols',
+    notification: {
+      type: 'notification',
+      text: 'Commit message: "fix: handle ✓ checksum & \u00e9\u00e0\u00fc in serial frames"',
+      category: 'generic',
+    },
+  },
+];
+
+// ── Output helpers ────────────────────────────────────────────────────────────
+
+const RESET  = '\x1b[0m';
+const BOLD   = '\x1b[1m';
+const DIM    = '\x1b[2m';
+const GREEN  = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED    = '\x1b[31m';
+const CYAN   = '\x1b[36m';
+
+function printResult(response) {
+  if (response.type === 'response') {
+    console.log(`  ${GREEN}Response:${RESET} action=${BOLD}${response.action}${RESET} label=${BOLD}${response.label || '(none)'}${RESET}`);
+  } else if (response.type === 'error') {
+    console.log(`  ${RED}Error:${RESET} ${response.error}`);
+  } else {
+    console.log(`  ${DIM}Unknown response:${RESET}`, JSON.stringify(response));
+  }
+}
+
+// ── Test runner ───────────────────────────────────────────────────────────────
+
+async function runTest(index, config) {
+  const test = TESTS[index];
+  console.log(`\n${CYAN}[${index + 1}] ${test.name}${RESET}`);
+
+  if (test.multi) {
+    // Send all in parallel, report each result as it arrives
+    const promises = test.notifications.map((n) => {
+      const notification = { ...n, id: randomUUID() };
+      console.log(`  ${DIM}Sending:${RESET} ${notification.text}`);
+      return sendNotification(config.endpoint, notification, config.timeoutMs)
+        .then((resp) => {
+          console.log(`  ${DIM}[${notification.text.slice(0, 40)}...]${RESET}`);
+          printResult(resp);
+        })
+        .catch((err) => {
+          console.log(`  ${RED}Error: ${err.message}${RESET}`);
+        });
+    });
+    await Promise.all(promises);
+  } else {
+    const notification = { ...test.notification, id: randomUUID() };
+    console.log(`  ${DIM}Text:${RESET}     ${notification.text}`);
+    console.log(`  ${DIM}Category:${RESET} ${notification.category}`);
+    try {
+      const response = await sendNotification(config.endpoint, notification, config.timeoutMs);
+      printResult(response);
+    } catch (err) {
+      console.log(`  ${RED}Error: ${err.message}${RESET}`);
+    }
+  }
+}
+
+async function runAll(config) {
+  console.log(`\n${BOLD}Running all ${TESTS.length} tests sequentially...${RESET}`);
+  for (let i = 0; i < TESTS.length; i++) {
+    await runTest(i, config);
+  }
+  console.log(`\n${GREEN}Done.${RESET}`);
+}
+
+// ── Interactive menu ──────────────────────────────────────────────────────────
+
+function printMenu() {
+  console.log(`\n${BOLD}camel-pad notification tests${RESET}\n`);
+  TESTS.forEach((t, i) => {
+    const tag = t.multi ? ` ${DIM}[multi]${RESET}` : '';
+    console.log(`  ${YELLOW}${i + 1}.${RESET} ${t.name}${tag}`);
+  });
+  console.log(`  ${YELLOW}a.${RESET} Run all`);
+  console.log(`  ${YELLOW}q.${RESET} Quit`);
+  console.log('');
+}
+
+async function interactiveMenu(config) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (prompt) => new Promise((resolve) => rl.question(prompt, resolve));
+
+  printMenu();
+
+  while (true) {
+    const answer = (await ask('Select: ')).trim().toLowerCase();
+
+    if (answer === 'q' || answer === 'quit') {
+      rl.close();
+      break;
+    }
+
+    if (answer === 'a' || answer === 'all') {
+      await runAll(config);
+      printMenu();
+      continue;
+    }
+
+    const n = parseInt(answer, 10);
+    if (!isNaN(n) && n >= 1 && n <= TESTS.length) {
+      await runTest(n - 1, config);
+    } else {
+      console.log(`${RED}Invalid selection.${RESET}`);
+    }
+  }
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const config = loadConfig();
+  console.log(`${DIM}Connecting to ${config.endpoint}${RESET}`);
+
+  const arg = process.argv[2];
+
+  if (!arg) {
+    await interactiveMenu(config);
+    return;
+  }
+
+  if (arg === 'all') {
+    await runAll(config);
+    return;
+  }
+
+  const n = parseInt(arg, 10);
+  if (!isNaN(n) && n >= 1 && n <= TESTS.length) {
+    await runTest(n - 1, config);
+  } else {
+    console.error(`Unknown argument: ${arg}`);
+    console.error(`Usage: node scripts/test-notifications.js [all | 1-${TESTS.length}]`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -107,7 +107,10 @@ export async function startBridge(configPath: string): Promise<BridgeHandle> {
   serialDevice.on('button', ({ buttonId, pressed }) => {
     pushLog('in', 'button', `${buttonId} ${pressed ? 'pressed' : 'released'}`);
     const num = parseInt(buttonId.replace('key', ''));
-    const remapped = `key${remapButtonIndex(num, handedness)}`;
+    // Seesaw buttons are physically ordered in reverse relative to display zones
+    // (seesaw index 0 = rightmost zone, 3 = leftmost) due to 90° display rotation.
+    // Convert seesaw index to display zone first, then apply handedness mapping.
+    const remapped = `key${remapButtonIndex(3 - num, handedness)}`;
     gestureDetector.handleButton(remapped, pressed);
   });
 
@@ -152,11 +155,15 @@ export async function startBridge(configPath: string): Promise<BridgeHandle> {
     serialDevice.sendText(message.text);
   });
 
-  // Clear display when all notifications are handled
+  // Clear display when all notifications are handled, then restore labels
   notificationServer.on('clear', () => {
+    const currentConfig = configWatcher.getConfig();
     pushLog('out', 'clear', 'Display cleared after response');
     console.log('Clearing display after response');
     serialDevice.clearDisplay();
+    const labels = extractLabelsForDisplay(currentConfig, handedness);
+    pushLog('out', 'labels', labels.join(' | '));
+    serialDevice.sendLabels(labels);
   });
 
   // Config reload events
@@ -216,7 +223,7 @@ export async function startBridge(configPath: string): Promise<BridgeHandle> {
       return serialDevice.clearDisplay();
     },
     sendLeds(leds: Array<{ index: number; r: number; g: number; b: number }>): boolean {
-      const remapped = leds.map(led => ({ ...led, index: remapButtonIndex(led.index, handedness) }));
+      const remapped = leds.map(led => ({ ...led, index: 3 - remapButtonIndex(led.index, handedness) }));
       pushLog('out', 'leds', leds.map(l => `[${l.index}] #${[l.r, l.g, l.b].map(v => v.toString(16).padStart(2, '0')).join('')}`).join(' '));
       return serialDevice.sendLeds(remapped);
     },


### PR DESCRIPTION
## Summary
- Fix seesaw button index remapping: physical buttons are reversed relative to display zones due to 90° rotation, so apply `(3 - index)` before handedness mapping
- Restore button labels after display clear (previously labels were lost after responding to a notification)
- Add `logger.js` module to plugin hook scripts for send/recv message visibility and improved debugging
- Add mise tasks (`run`, `build`, `test-notification`) and `scripts/test-notifications.js` helper

## Test plan
- [x] Press each physical button and verify the correct display zone highlights
- [x] Send a notification, respond, confirm labels are restored on the display
- [x] Check plugin hook log output for send/recv messages during notification flow
- [x] Run `mise run test-notification` to verify the test script works

🤖 Generated with [Claude Code](https://claude.com/claude-code)