### PR TITLE
fix(settings): lock header and tab bar during scroll

### DIFF
--- a/src/static/tray.html
+++ b/src/static/tray.html
@@ -101,6 +101,10 @@
         --dir-sys-bg: rgba(0, 0, 0, 0.05);
       }
 
+      html {
+        height: 100%;
+      }
+
       body {
         font-family: var(--sans);
         font-size: 13px;
@@ -121,6 +125,10 @@
         min-width: 480px;
         max-width: 600px;
         margin: 0 auto;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
       }
 
       /* ── App header ── */
@@ -204,6 +212,8 @@
       /* ── Content ── */
       .content {
         padding: 16px 20px 24px;
+        flex: 1;
+        overflow-y: auto;
       }
 
       /* ── Views ── */


### PR DESCRIPTION
## Summary
- Makes the body a flex column at full viewport height so only the `.content` area scrolls
- Header (brand + connection status) and tab bar remain fixed while content scrolls
- Adds `html { height: 100% }` to anchor the layout, `body { height: 100%; display: flex; flex-direction: column; overflow: hidden }`, and `.content { flex: 1; overflow-y: auto }`

Closes #31

## Test plan
- [x] Open the settings popover and scroll down — header and tab bar stay pinned at the top
- [x] Switch between tabs — scroll position resets, header/tab bar remain fixed
- [x] Verify in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)